### PR TITLE
Refatora script de importação e melhora performance

### DIFF
--- a/import_from_csv.rb
+++ b/import_from_csv.rb
@@ -1,30 +1,46 @@
 require 'csv'
+require 'benchmark'
 require_relative 'lib/patient'
 require_relative 'lib/doctor'
 require_relative 'lib/lab_exam'
 require_relative 'lib/test'
+require_relative 'lib/database/database_connection'
 
 rows = CSV.read('./data.csv', col_sep: ';')
 rows.shift
 
 puts 'Importando dados...'
 
-rows.each do |row|
-  cpf, name, email, birthdate, address, city, state = row[0..6]
-  patient = Patient.find_by(cpf:)[0]
-  patient ||= Patient.create(cpf:, name:, email:, birthdate:, address:, city:, state:)
+connection = DatabaseConnection.connect
 
-  crm, crm_state, name, email = row[7..10]
-  doctor = Doctor.find_by(crm:, crm_state:)[0]
-  doctor ||= Doctor.create(crm:, crm_state:, name:, email:)
+time = Benchmark.measure do
+  connection.transaction do  |conn|
+    rows.each_with_index do |row|
+      close_connection = false
 
-  result_token, result_date = row[11..12]
-  lab_exam = LabExam.find_by(result_token:)[0]
-  lab_exam ||= LabExam.create(patient_id: patient.id, doctor_id: doctor.id,
-                              result_token:, result_date:)
+      cpf, name, email, birthdate, address, city, state = row[0..6]
+      patient = Patient.find_by({ cpf: }, conn:, close_connection:)[0]
+      patient ||= Patient.create({ cpf:, name:, email:, birthdate:, address:, city:, state: },
+                                   conn:, close_connection:)
 
-  type, type_limits, type_results = row[13..15]
-  Test.create(lab_exam_id: lab_exam.id, type:, type_limits:, type_results:)
+      crm, crm_state, name, email = row[7..10]
+      doctor = Doctor.find_by({ crm:, crm_state: }, conn:, close_connection:)[0]
+      doctor ||= Doctor.create({ crm:, crm_state:, name:, email: },
+                                 conn:, close_connection:)
+
+      result_token, result_date = row[11..12]
+      lab_exam = LabExam.find_by({ result_token: }, conn:, close_connection:)[0]
+      lab_exam ||= LabExam.create({ patient_id: patient.id, doctor_id: doctor.id,
+                                  result_token:, result_date: }, conn:, close_connection:)
+
+      type, type_limits, type_results = row[13..15]
+      Test.create({ lab_exam_id: lab_exam.id, type:, type_limits:, type_results: },
+                    conn:, close_connection:)
+    end
+  end
 end
 
+connection.close if connection
+
 puts 'Dados importados com sucesso'
+puts "Tempo de execução: #{time.real}"


### PR DESCRIPTION
Esse PR resolve #3 

Foram refatorados o script de importação `import_from_csv.rb` e os métodos `.create` e `.find_by` da classe `BaseModel` para utilizar apenas uma conexão em vez de uma conexão a cada chamada dos métodos

Antes

![image](https://github.com/paulohenrique-gh/td11-rebase-labs/assets/124916478/5385c346-15e6-48e5-8597-e5549c5ff843)

Depois

![image](https://github.com/paulohenrique-gh/td11-rebase-labs/assets/124916478/6bfa0a17-4028-4e62-bd92-eaee488e0490)
